### PR TITLE
Update PredictorCache to .net6.0 framework

### DIFF
--- a/src/PredictorCache/ICacheService.cs
+++ b/src/PredictorCache/ICacheService.cs
@@ -13,21 +13,20 @@ namespace LLMEmpoweredCommandPredictor.PredictorCache;
 public interface ICacheService
 {
     /// <summary>
-    /// Gets cached suggestions for the given cache key.
+    /// Gets cached string response for the given cache key.
     /// </summary>
     /// <param name="cacheKey">The cache key to look up</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Cached suggestions or null if not found/expired</returns>
-    Task<IReadOnlyList<PredictiveSuggestion>?> GetAsync(string cacheKey, CancellationToken cancellationToken = default);
+    /// <returns>Cached response or null if not found/expired</returns>
+    Task<string?> GetAsync(string cacheKey, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Stores suggestions in the cache with the given key.
+    /// Stores string response in the cache with the given key.
     /// </summary>
     /// <param name="cacheKey">The cache key to store under</param>
-    /// <param name="suggestions">The suggestions to cache</param>
-    /// <param name="ttl">Time-to-live for the cache entry</param>
+    /// <param name="response">The response to cache</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    Task SetAsync(string cacheKey, IReadOnlyList<PredictiveSuggestion> suggestions, TimeSpan ttl, CancellationToken cancellationToken = default);
+    Task SetAsync(string cacheKey, string response, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Removes a specific cache entry.

--- a/src/PredictorCache/LLMEmpoweredCommandPredictor.PredictorCache.csproj
+++ b/src/PredictorCache/LLMEmpoweredCommandPredictor.PredictorCache.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/PredictorCache.Tests/PredictorCache.Tests.csproj
+++ b/tests/PredictorCache.Tests/PredictorCache.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/PredictorCache.Tests/README.md
+++ b/tests/PredictorCache.Tests/README.md
@@ -1,0 +1,26 @@
+# PredictorCache.Tests
+
+## Overview
+
+This test project contains unit tests for the **LLMEmpoweredCommandPredictor.PredictorCache** module.
+
+### 📋 Test Classes
+
+#### `CacheKeyGeneratorTests`
+Tests the cache key generation logic that creates unique identifiers for cache entries based on user input and project context.
+
+#### `InMemoryCacheTests`
+Tests the in-memory cache implementation that stores LLM responses with TTL (Time-To-Live) and LRU (Least Recently Used) eviction.
+
+## 🚀 Running Tests
+
+### Prerequisites
+- .NET 6.0 or later
+- xUnit test framework
+
+### Commands
+
+```bash
+dotnet build tests/PredictorCache.Tests/PredictorCache.Tests.csproj  
+dotnet test tests/PredictorCache.Tests/PredictorCache.Tests.csproj 
+```


### PR DESCRIPTION
PredictorCache previously using .net8.0 framework. Moving it to .net6.0 for better integration with other projects