### PR TITLE
update doc

### DIFF
--- a/src/PredictorPlugin/README.md
+++ b/src/PredictorPlugin/README.md
@@ -34,7 +34,7 @@ dotnet build -c Release
 
 ```powershell
 Import-Module ".\bin\Release\LLMEmpoweredCommandPredictor\net6.0\LLMEmpoweredCommandPredictor.dll" -Verbose
-Set-PSReadLineOption -PredictionSource HistoryAndPlugin
+Set-PSReadLineOption -PredictionSource Plugin
 ```
 
 4. Start using the command predictor:


### PR DESCRIPTION
After investigation, we need to use 
Set-PSReadLineOption -PredictionSource Plugin
instead of 
Set-PSReadLineOption -PredictionSource HistoryAndPlugin

Note: 
History is something embedded inside Powershell. By doing HistoryAndPlugin, we are activating both History and Plugin. So the outputs are conflicting. User sees whichever is returned faster.